### PR TITLE
move notFound function in route list

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ express()
 
     .use(express.static("static"))
     .use("/static/images/", express.static("./static/images"))
+    .use(notFound)
     .set("view engine", "ejs")
     .set("views", "view")
-    .use(notFound)
     .listen(process.env.PORT || 8000);
 
 function notFound(req, res) {


### PR DESCRIPTION
Fix for error 12 or 24 string, by moving the notFound function in the routes list. 