### PR TITLE
add not equel rule in db.listCollections

### DIFF
--- a/route/searchLocation.js
+++ b/route/searchLocation.js
@@ -39,7 +39,7 @@ router
     
 
 function get(req, res, next) {
-    db.listCollections().toArray(done);
+    db.listCollections({ name: { $ne: "members" } }).toArray(done);
     
     function done(err, data) {
         if (err) {


### PR DESCRIPTION
In the list of game collections, the collection members was displayed as well. This collection is used for register and log in. So, the goal is to show every collection except the collection Members.